### PR TITLE
Remove long URL links when printing vouchers with uploads

### DIFF
--- a/ifms/views/backend/partner/dct_view_voucher.php
+++ b/ifms/views/backend/partner/dct_view_voucher.php
@@ -2,6 +2,14 @@
     extract($record);
 ?>
 
+<style>
+@media print {
+  a[href]:after {
+    content: none !important;
+  }
+}
+</style>
+
 <table class="table table-striped datatable">
     <thead>
         <tr>


### PR DESCRIPTION
Remove long URL links when printing vouchers with uploads